### PR TITLE
Feature/persistent docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Available variables are listed below, along with default values (see `defaults/m
     vulhub_install_path: /opt/vulhub
     vulhub_branch: master
     vulhub_envs:
+    vulhub_persistent: true
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ vulhub_git_url: https://github.com/vulhub/vulhub
 vulhub_install_path: /opt/vulhub
 vulhub_branch: master
 vulhub_envs:
+vulhub_persistent: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,9 +44,8 @@
 - name: Start the vulhub environments (shell) - persistent
   ansible.builtin.shell:
     cmd: |
-      yq eval '(.services[] |= (del(.ports))' -i {{ vulhub_install_path }}/{{ vulhub_env }}/docker-compose.yml
-      PERSISTENCE_FILTER='(.services[] |= . + {"restart": "always", "network_mode": "host", "init": true}))'
-      yq eval "$PERSISTENCE_FILTER" -i {{ vulhub_install_path }}/{{ vulhub_env }}/docker-compose.yml
+      yq eval '(.services[] |= (del(.ports)))' -i {{ vulhub_install_path }}/{{ vulhub_env }}/docker-compose.yml
+      yq eval '(.services[] |= . + {"restart": "always", "network_mode": "host"})' -i {{ vulhub_install_path }}/{{ vulhub_env }}/docker-compose.yml
       docker compose build
       docker compose up -d
     chdir: "{{ vulhub_install_path }}/{{ vulhub_env }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,24 +4,36 @@
     name: git
     state: present
 
-#This hardcodes the architecture and version -- not the way I want to do this
+- name: Install curl if required
+  ansible.builtin.package:
+    name: curl
+    state: present
+
+- name: Identify latest yq binary
+  ansible.builtin.package:
+    name: git
+    state: present
+
+- name: Get latest yq version
+  ansible.builtin.shell: |
+    curl -sLI https://github.com/mikefarah/yq/releases/latest | grep -ioP 'location.*/tag/\Kv\d+\.\d+\.\d+' | tail -1
+  register: yq_version
+  changed_when: false
+
 - name: Download yq binary
-  get_url:
-    url: "https://github.com/mikefarah/yq/releases/download/v4.45.4/yq_linux_amd64"
-    dest: "/usr/local/bin/yq"
+  ansible.builtin.get_url:
+    url: "https://github.com/mikefarah/yq/releases/download/{{ yq_version.stdout }}/yq_linux_amd64"
+    dest: "/usr/bin/yq"
     mode: "0755"
 
-- name: Move yq to /usr/bin
-  command: mv /usr/local/bin/yq /usr/bin/yq
-  args:
-    creates: /usr/bin/yq
-
+# we add a force because we end up modifying some files if we go the persistent route
 - name: Get the source code
   ansible.builtin.git:
     repo: "{{ vulhub_git_url }}"
     dest: "{{ vulhub_install_path }}"
     version: "{{ vulhub_branch }}"
     single_branch: true
+    force: true
 
 - name: Stop any existing vulhub docker containers
   ansible.builtin.shell: |
@@ -29,14 +41,31 @@
      grep 'com.docker.compose.project.config_files={{ vulhub_install_path }}' | cut -d ' ' -f 1 | xargs -r docker stop
 
 # community.docker.docker_compose has too many dependencies
-# Added changes to docker-compose.yml to make it persistent and use host networking
-- name: Start the vulhub environments (shell)
+- name: Start the vulhub environments (shell) - persistent
   ansible.builtin.shell:
     cmd: |
-      yq eval '(.services[] |= (del(.ports) | . + {"restart": "always", "network_mode": "host", "init": true}))' -i {{ vulhub_install_path }}/{{ vulhub_env }}/docker-compose.yml
+      yq eval '(.services[] |= (del(.ports))' -i {{ vulhub_install_path }}/{{ vulhub_env }}/docker-compose.yml
+      PERSISTENCE_FILTER='(.services[] |= . + {"restart": "always", "network_mode": "host", "init": true}))'
+      yq eval "$PERSISTENCE_FILTER" -i {{ vulhub_install_path }}/{{ vulhub_env }}/docker-compose.yml
       docker compose build
       docker compose up -d
     chdir: "{{ vulhub_install_path }}/{{ vulhub_env }}"
   loop: "{{ vulhub_envs }}"
   loop_control:
     loop_var: vulhub_env
+  when: vulhub_persistent
+  register: vulhub_output
+  changed_when: "'Building' in vulhub_output.stdout or 'Creating' in vulhub_output.stdout"
+
+- name: Start the vulhub environments (shell) - non-persistent
+  ansible.builtin.shell:
+    cmd: |
+      docker compose build
+      docker compose up -d
+    chdir: "{{ vulhub_install_path }}/{{ vulhub_env }}"
+  loop: "{{ vulhub_envs }}"
+  loop_control:
+    loop_var: vulhub_env
+  when: not vulhub_persistent
+  register: compose_output
+  changed_when: "'Building' in compose_output.stdout or 'Creating' in compose_output.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,8 +16,6 @@
   args:
     creates: /usr/bin/yq
 
-
-
 - name: Get the source code
   ansible.builtin.git:
     repo: "{{ vulhub_git_url }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,20 @@
     name: git
     state: present
 
+#This hardcodes the architecture and version -- not the way I want to do this
+- name: Download yq binary
+  get_url:
+    url: "https://github.com/mikefarah/yq/releases/download/v4.45.4/yq_linux_amd64"
+    dest: "/usr/local/bin/yq"
+    mode: "0755"
+
+- name: Move yq to /usr/bin
+  command: mv /usr/local/bin/yq /usr/bin/yq
+  args:
+    creates: /usr/bin/yq
+
+
+
 - name: Get the source code
   ansible.builtin.git:
     repo: "{{ vulhub_git_url }}"
@@ -17,9 +31,11 @@
      grep 'com.docker.compose.project.config_files={{ vulhub_install_path }}' | cut -d ' ' -f 1 | xargs -r docker stop
 
 # community.docker.docker_compose has too many dependencies
+# Added changes to docker-compose.yml to make it persistent and use host networking
 - name: Start the vulhub environments (shell)
   ansible.builtin.shell:
     cmd: |
+      yq eval '(.services[] |= (del(.ports) | . + {"restart": "always", "network_mode": "host", "init": true}))' -i {{ vulhub_install_path }}/{{ vulhub_env }}/docker-compose.yml
       docker compose build
       docker compose up -d
     chdir: "{{ vulhub_install_path }}/{{ vulhub_env }}"


### PR DESCRIPTION
I noticed that the existing role does not persist on reboots or use host networking if I wanted to do something like a reverse shell.

By modifying docker-compose.yml with the following lines, we can make our docker persistent:

```
    restart: always
    network_mode: host
    init: true
```

This modification is done with yq, and I've hardcoded the version and architecture so there may be a more elegant way to handle this.