### PR TITLE
Add support for local custom vulhub files and update README variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,8 @@ Temporary Items
 .history
 .ionide
 
+files/**
+!files/
+!files/README.md
+
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,ansible

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Available variables are listed below, along with default values (see `defaults/m
     vulhub_branch: master
     vulhub_envs:
     vulhub_persistent: true
+    use_local_vulhub_files: false
+    local_vulhub_files_path: "{{ playbook_dir | default(omit) }}/roles/ludus_vulhub/files"
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,5 @@ vulhub_install_path: /opt/vulhub
 vulhub_branch: master
 vulhub_envs:
 vulhub_persistent: true
+use_local_vulhub_files: false
+local_vulhub_files_path: "{{ playbook_dir | default(omit) }}/roles/ludus_vulhub/files"

--- a/files/README.md
+++ b/files/README.md
@@ -1,0 +1,7 @@
+### README for files/ directory
+#### But why? 
+In the event you don't want to expose your custom files publicly in a repository, you can place them here.
+#### Info
+- Directory for placing local customized [vulhub](https://github.com/vulhub/vulhub) files/directories to be used by the ludus_vulhub role.
+- These files will be copied to /opt/vulhub (or the path specified by `vulhub_install_path`) on the target host.
+- If you want to use a local copy of vulhub files instead of cloning from GitHub, set `use_local_vulhub_files` to true.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,14 +26,36 @@
     dest: "/usr/bin/yq"
     mode: "0755"
 
+
+- name: Ensure vulhub install path exists
+  ansible.builtin.file:
+    path: "{{ vulhub_install_path }}"
+    state: directory
+    mode: '0755'
+
+- name: Copy selected vulhub environments from role files (controller -> remote)
+  ansible.builtin.copy:
+    src: "{{ role_path }}/files/{{ item }}/"
+    dest: "{{ vulhub_install_path }}/{{ item }}"
+    owner: "root"
+    group: "root"
+    mode: '0755'
+    remote_src: no
+    force: true
+  loop: "{{ vulhub_envs }}"
+  loop_control:
+    loop_var: item
+  when: use_local_vulhub_files
+
 # we add a force because we end up modifying some files if we go the persistent route
-- name: Get the source code
+- name: Get the source code from git 
   ansible.builtin.git:
     repo: "{{ vulhub_git_url }}"
     dest: "{{ vulhub_install_path }}"
     version: "{{ vulhub_branch }}"
     single_branch: true
     force: true
+  when: not use_local_vulhub_files
 
 - name: Stop any existing vulhub docker containers
   ansible.builtin.shell: |


### PR DESCRIPTION
### What 
This change is to allow users the ability to ship custom vulhub setups without exposing them publicly on git. 

### Changes: 
- Introduced variables for using local customized vulhub files in the Ansible role.
- Updated tasks to copy local files if specified.
- Added a README for the new files directory to explain usage.
